### PR TITLE
修改了FancyBar中导致CPU占用过高的问题

### DIFF
--- a/src/libs/qcanpool/fancybar.cpp
+++ b/src/libs/qcanpool/fancybar.cpp
@@ -677,9 +677,6 @@ void FancyBarPrivate::handleWidgetMouseEvent(QObject *obj, QEvent *event)
     Q_UNUSED(obj);
 
     switch (event->type()) {
-    default:
-        break;
-
     case QEvent::MouseButtonPress:
         handleMousePressEvent(static_cast<QMouseEvent *>(event));
         break;
@@ -698,6 +695,8 @@ void FancyBarPrivate::handleWidgetMouseEvent(QObject *obj, QEvent *event)
 
     case QEvent::HoverMove:
         handleHoverMoveEvent(static_cast<QHoverEvent *>(event));
+        break;
+    default:
         break;
     }
 }
@@ -1264,8 +1263,7 @@ bool FancyBar::eventFilter(QObject *object, QEvent *event)
     default:
         break;
     }
-
-    return QObject::eventFilter(object, event);
+    return true;
 }
 
 #include "fancybar.moc"


### PR DESCRIPTION
```
    virtual bool eventFilter(QObject* object, QEvent* event);
```
问题

把最后的QObject处理删掉，直接返回true。